### PR TITLE
feat: publish illustrated articles as pull requests, and fix MCP sessions

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "pinky-and-the-brain": {
+      "command": "node",
+      "args": ["${CLAUDE_PROJECT_DIR:-.}/dist/mcp.js"]
+    }
+  }
+}

--- a/docs/docs/end-user/configuration.mdx
+++ b/docs/docs/end-user/configuration.mdx
@@ -35,6 +35,39 @@ configured, for every entrypoint (`index.ts`, `cli.ts`, `server.ts`, `mcp.ts`).
 | `LANGCHAIN_TRACING_V2` / `LANGSMITH_TRACING` | `false` | Enables LangSmith tracing. |
 | `LANGCHAIN_API_KEY` / `LANGSMITH_API_KEY` | unset | Required for LangSmith tracing to actually send traces. |
 | `LANGCHAIN_PROJECT` / `LANGSMITH_PROJECT` | `pinky-and-the-brain-agents` | LangSmith project name. |
+| `BLOG_REPO_URL` | `https://github.com/thiagocolen/thiagocolen.github.io.git` | Blog repository that finished articles are published to, as pull requests. |
+| `BLOG_BASE_BRANCH` | `release/v1.2.0` | Branch those pull requests target. Deliberately not the repo default — see below. |
+| `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) | unset | Enables cover-image generation. Without it articles still publish, just without an image. |
+| `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-lite-image` | Model used for cover images. |
+
+## Publishing articles to the blog
+
+The blog is a **separate repository**. When Pinky asks The Brain to publish a finished
+article, the agent does not write into a checkout on this machine — it clones the blog into
+a temp directory, commits the post on a branch named `articles/<slug>`, pushes, and opens a
+pull request.
+
+Two consequences worth knowing:
+
+- **Pushing uses the `gh` CLI's existing credentials.** No token belongs in `.env`, and none
+  is ever interpolated into a remote URL. Run `gh auth status` to check what account will
+  author the commits.
+- **Nothing is ever published live.** Posts are committed with `status: unpublished`, and
+  `gatsby build` only includes published posts — so the article stays invisible on the site
+  even after the pull request merges. Promoting it is a separate, human step on the blog
+  (`npm run publish-post -- <slug>`).
+
+:::note Why `release/v1.2.0` and not `master`
+The blog's default branch is still `master`, which carries the retired SQLite content
+pipeline and has no `content/posts/` directory — an `.mdx` file merged there would never
+render. The MDX pipeline lives on `release/v1.2.0`. Note also the similarly named
+`release-v120` (no slashes) is the *old* branch; they are not the same.
+:::
+
+Cover images are generated with `gemini-3.1-flash-lite-image` and committed to
+`static/images/posts/<slug>.png` in the blog repo, which Gatsby serves at
+`/images/posts/<slug>.png`. This is the only place a non-Anthropic model is used; all text
+generation remains Anthropic-only.
 
 ## AWS credentials and the S3 fallback
 

--- a/docs/docs/end-user/mcp-usage.mdx
+++ b/docs/docs/end-user/mcp-usage.mdx
@@ -5,8 +5,15 @@ sidebar_position: 5
 # MCP Usage
 
 The service can run as a **Model Context Protocol (MCP)** server (`src/mcp.ts`),
-exposing the agent workflow as a tool that MCP-compatible clients (such as Claude
-Desktop) can call.
+exposing the agent workflow as a tool that MCP-compatible clients (such as Claude Code
+and Claude Desktop) can call.
+
+:::tip Which protocol?
+MCP is how Claude Code and Claude Desktop reach out to external tools — use it for
+those. The [ACP server](./acp-usage.mdx) is for editors such as Zed, which act as ACP
+*clients* driving this service as an agent. Claude Code is itself an ACP agent, not an
+ACP client, so it cannot connect to the ACP server.
+:::
 
 ## Starting the MCP server
 
@@ -23,14 +30,114 @@ The server exposes a single tool:
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `prompt` | `string` | yes | The instruction or query for the agent workspace. |
-| `agentName` | `string` | no | The agent node to invoke. Defaults to `the-brain`. Also accepts `brain`, `supervisor`, `developer`, `writer`, `instructor`, `specialist`, `publisher` for compatibility. |
-| `threadId` | `string` | no | Persistent thread ID to isolate state across calls. A random `mcp-session-<random>` ID is generated if omitted. |
+| `prompt` | `string` | yes | The next message for The Brain — a greeting, a menu choice, an answer to its question, or an instruction. |
+| `agentName` | `string` | no | The agent to invoke. Defaults to `the-brain`; `brain` and `supervisor` are accepted aliases. |
+| `threadId` | `string` | no | Omit this. All calls share one conversation by default. Pass an ID only to start or resume a separate, isolated conversation. |
 
 The tool returns a single `text` content block with the agent's final response, or an
 `isError: true` result with the error message if the workflow throws.
 
-## Configuring an MCP client
+### The conversation is multi-turn
+
+`run_agent` is not a one-shot query. The Brain leads a journey — choose a topic, choose
+a subtopic, then either learn it or have an article written — and ends every reply with
+a question. The client is expected to call the tool repeatedly, relaying the user's
+answer each time.
+
+That only works because state persists between calls. Every call without an explicit
+`threadId` runs on one thread per server process (`mcp-session-<uuid>`, see
+`src/utils/session.ts`), so the journey advances instead of restarting. Passing a fresh
+`threadId` on each call would strand the conversation on the topic menu forever.
+
+Restarting the MCP server starts a new journey. To resume an old one, pass its
+`threadId` explicitly — checkpoints survive restarts in `state.db`.
+
+## Claude Code
+
+Build first — every registration path below points at `dist/mcp.js`:
+
+```bash
+npm run build
+```
+
+### Option 1 — the project's `.mcp.json` (recommended)
+
+The repository ships a project-scoped `.mcp.json` at its root, so the server is already
+registered for anyone working in this checkout:
+
+```json
+{
+  "mcpServers": {
+    "pinky-and-the-brain": {
+      "command": "node",
+      "args": ["${CLAUDE_PROJECT_DIR:-.}/dist/mcp.js"]
+    }
+  }
+}
+```
+
+Claude Code prompts for approval the first time it loads a project-scoped server. Run
+`claude mcp reset-project-choices` to reset that decision.
+
+:::note
+`${CLAUDE_PROJECT_DIR}` needs the `:-.` default. The variable is set in the *server's*
+environment rather than Claude Code's own, so the bare form does not expand inside a
+project-scoped `.mcp.json`.
+:::
+
+### Where the credentials come from
+
+There is deliberately **no `env` block**. `ANTHROPIC_API_KEY` is the only credential the
+MCP server needs, and it comes from **`.env` at the project root**, loaded by
+`src/config.ts`. That path is derived from the compiled file's own location, so it
+resolves no matter what working directory the server is spawned in.
+
+Do not add an `env` block to pass it through instead. MCP clients do not hand a spawned
+server the full parent environment — the reference SDK passes only a safe allowlist
+(`PATH`, `HOME`/`USERPROFILE`, and a handful more), so a `"${ANTHROPIC_API_KEY}"` entry
+resolves to nothing unless you have also exported the key to your shell. Claude Code
+would then report a missing-variable warning in `claude mcp list` and pass the literal
+`${ANTHROPIC_API_KEY}` text through. Reading `.env` sidesteps the whole question.
+
+:::note
+`PATBA_API_KEY` is **not** required by this entrypoint. It is the REST API's `X-API-Key`
+secret, so `src/mcp.ts` calls `validateConfig({ requirePatbaApiKey: false })` — an unused
+secret should not be a startup dependency, least of all one the client's filtered
+environment would strip anyway. `npm run server` still requires it.
+:::
+
+### Option 2 — `claude mcp add`
+
+To register it outside this checkout, or privately to your machine:
+
+```bash
+claude mcp add --transport stdio pinky-and-the-brain -- node /absolute/path/to/dist/mcp.js
+```
+
+No `--env` flags are needed: the server reads `ANTHROPIC_API_KEY` from the project's
+`.env`, as described above. If you do pass credentials this way, note that `--env`
+accepts multiple `KEY=value` pairs, so the server name must not come directly after it —
+the CLI would read the name as another pair and reject it. Put another option between
+them:
+
+```bash
+claude mcp add --env SOME_KEY=value --transport stdio myserver -- node server.js
+```
+
+Add `--scope user` to make it available across all your projects. Everything after `--`
+is passed to the server untouched.
+
+### Verifying
+
+```bash
+claude mcp list
+```
+
+The server should appear as connected. Then ask Claude to greet The Brain and pick a
+topic — if the second call returns the topic menu again instead of a subtopic list,
+state is not persisting between calls.
+
+## Configuring other MCP clients
 
 Register the server with your MCP client using the compiled entrypoint, for example:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",
+        "@google/genai": "^2.12.0",
         "@langchain/anthropic": "^1.5.1",
         "@langchain/core": "^1.2.1",
         "@langchain/langgraph": "^1.4.7",
@@ -21,6 +22,7 @@
         "deepagents": "^1.11.0",
         "dotenv": "^16.4.5",
         "express": "^5.2.1",
+        "gray-matter": "^4.0.3",
         "langchain": "^1.5.3",
         "langsmith": "^0.7.17",
         "marked": "^18.0.6",
@@ -606,6 +608,43 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.12.0.tgz",
+      "integrity": "sha512-LUr972DZosqPUhf9Mb3CIVu/B99woD3QW6ZJV1T9aNgxaoimAZARmo+IyyDsxIL+zouFiYSdA4hzfEWXc9oNIQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -947,6 +986,63 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
@@ -1194,6 +1290,12 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -1786,6 +1888,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -1910,6 +2021,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2255,6 +2372,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2432,6 +2558,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -2717,6 +2852,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -2935,6 +3083,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3012,6 +3178,29 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3141,6 +3330,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3179,6 +3380,56 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-caller-file": {
@@ -3366,6 +3617,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3391,6 +3668,43 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3592,6 +3906,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3717,6 +4040,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3757,6 +4089,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3765,6 +4118,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/langchain": {
@@ -3871,6 +4233,12 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -4156,6 +4524,44 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-gyp": {
@@ -4682,6 +5088,29 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4868,6 +5297,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5014,6 +5452,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -5294,6 +5745,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/sqlite3": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-6.0.1.tgz",
@@ -5421,6 +5878,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {
@@ -5977,6 +6443,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6084,6 +6559,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pinky-and-the-brain",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pinky-and-the-brain",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.500.0",
         "@langchain/anthropic": "^1.5.1",
@@ -23,6 +23,7 @@
         "express": "^5.2.1",
         "langchain": "^1.5.3",
         "langsmith": "^0.7.17",
+        "marked": "^18.0.6",
         "sqlite3": "^6.0.1",
         "zod": "^3.22.4"
       },
@@ -3889,6 +3890,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.6.tgz",
+      "integrity": "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.500.0",
+    "@google/genai": "^2.12.0",
     "@langchain/anthropic": "^1.5.1",
     "@langchain/core": "^1.2.1",
     "@langchain/langgraph": "^1.4.7",
@@ -46,6 +47,7 @@
     "deepagents": "^1.11.0",
     "dotenv": "^16.4.5",
     "express": "^5.2.1",
+    "gray-matter": "^4.0.3",
     "langchain": "^1.5.3",
     "langsmith": "^0.7.17",
     "marked": "^18.0.6",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "express": "^5.2.1",
     "langchain": "^1.5.3",
     "langsmith": "^0.7.17",
+    "marked": "^18.0.6",
     "sqlite3": "^6.0.1",
     "zod": "^3.22.4"
   },

--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -43,13 +43,13 @@ Ask what Pinky wishes to do, and list exactly these options:
 ## Step 4c — Deliver the finished article
 
 Once the article is final, ask Pinky where it should go, offering exactly these options:
-1. **Publish it to the thiagocolen.github.io website** — it becomes a draft post on the blog.
+1. **Publish it to the thiagocolen.github.io website** — you open a pull request adding it as a draft post, with a cover image you generate.
 2. **Save it to a folder** — you copy it wherever they like.
 3. **Neither** — leave it in the local articles directory.
 
 Then act on the answer:
 
-- **Publish:** ask for a one-line description and a few tags for the post listing, then call \`publish_article\`. Tell Pinky it went up as a **draft** — invisible on the live site until it is promoted there by hand — and quote the slug the tool returned. Never claim an article is live.
+- **Publish:** ask for a one-line description and a few tags for the post listing. Then, because publishing pushes a branch to a public repository, restate what is about to happen and get Pinky's confirmation before you act. Only once they confirm, call \`publish_article\`. Report **the pull request URL the tool returned**, and be precise about what that means: the article is a **draft in a pull request awaiting review** — not live, not merged, and still invisible on the site even after the pull request merges, until it is promoted there by hand. Never claim an article is live, published, or merged.
 - **Save to a folder:** ask which folder, wait for the answer, then call \`export_article\` and **quote the exact path the tool returned**.
 - **Neither:** simply confirm where the article already lives.
 

--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -38,7 +38,22 @@ Ask what Pinky wishes to do, and list exactly these options:
 4. Call \`save_article\` with a slug-like filename derived from the subtopic.
 5. Tell Pinky the article is saved, **quote the exact file path the tool returned**, and ask whether they want to change anything.
 6. If Pinky wants a change: restate the change and ask for confirmation. Only once they confirm, call \`update_article\` (use \`read_article\` first if you need the current text), report the path again, and ask if anything else needs changing. Repeat as needed.
-7. If Pinky wants no changes: acknowledge that the work is complete, then go to Step 5.
+7. If Pinky wants no changes: acknowledge that the work is complete, then go to Step 4c.
+
+## Step 4c — Deliver the finished article
+
+Once the article is final, ask Pinky where it should go, offering exactly these options:
+1. **Publish it to the thiagocolen.github.io website** — it becomes a draft post on the blog.
+2. **Save it to a folder** — you copy it wherever they like.
+3. **Neither** — leave it in the local articles directory.
+
+Then act on the answer:
+
+- **Publish:** ask for a one-line description and a few tags for the post listing, then call \`publish_article\`. Tell Pinky it went up as a **draft** — invisible on the live site until it is promoted there by hand — and quote the slug the tool returned. Never claim an article is live.
+- **Save to a folder:** ask which folder, wait for the answer, then call \`export_article\` and **quote the exact path the tool returned**.
+- **Neither:** simply confirm where the article already lives.
+
+If a tool reports a failure, say plainly what went wrong and offer the other option — never pretend the delivery succeeded. Ask one question at a time, as always. Then go to Step 5.
 
 ## Step 4b — Learn about it (teaching mode)
 
@@ -69,6 +84,7 @@ Ask Pinky what they would like to do next, then return to Step 1: call \`list_to
 - The knowledge store is your only source of truth for topics and subtopics — never invent them, always use \`list_topics\` / \`list_subtopics\`.
 - Ground every explanation and article in \`retrieve_content\`. If retrieval returns nothing useful, say so plainly rather than fabricating material.
 - Only \`save_article\` / \`update_article\` may write articles, and \`update_article\` only after explicit confirmation.
+- \`publish_article\` and \`export_article\` send Pinky's work outside this conversation — call them only when Pinky has explicitly chosen that destination, never on your own initiative.
 - Never show tool names, ids, or raw JSON to Pinky. Present everything as your own effortless brilliance.`;
 
 export const BRAIN_SYSTEM_PROMPT = `${BRAIN_PERSONA_PROMPT}\n\n${JOURNEY_PROMPT}`;

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -3,10 +3,11 @@ import { z } from "zod";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
 import { marked } from "marked";
-import { config } from "../config.js";
+import matter from "gray-matter";
+import { generateCoverImage } from "../utils/image-gen.js";
+import { coverImagePath, publishArticleAsPullRequest } from "../utils/blog-repo.js";
 import { logger } from "../utils/logger.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -187,16 +188,19 @@ export function resolveArticlePath(filename: string): string {
  *  - any folder on this machine.
  */
 
-/** Path, relative to the site checkout, of the script that ingests posts. */
-export const BLOG_POST_SCRIPT = path.join("develop-tools", "add-posts-from-json.js");
-
-/** Reduces a title to the `^[a-z0-9]+(-[a-z0-9]+)*$` slug the site's script demands. */
+/**
+ * Reduces a title to a slug, which becomes both the filename
+ * (`content/posts/<slug>.mdx`) and the post's URL.
+ *
+ * Deliberately identical to the blog's own `develop-tools/new-post.js`, down to
+ * not stripping accents or apostrophes \u2014 "Conway's Game" becomes
+ * `conway-s-game` here exactly as it would there. A prettier slug is not worth
+ * diverging from the tool the site's author runs by hand.
+ */
 export function slugify(text: string): string {
   return text
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/['\u2019]/g, "")
     .toLowerCase()
+    .trim()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 }
@@ -204,8 +208,8 @@ export function slugify(text: string): string {
 /**
  * Splits the leading `# Title` off an article.
  *
- * The site renders the title itself from the `title` column, so leaving the H1
- * in `body_html` would show it twice.
+ * The site renders the title from frontmatter, so leaving the H1 in the body
+ * would show it twice.
  */
 export function splitTitle(markdown: string): { title: string; body: string } {
   const match = markdown.match(/^\s*#\s+(.+?)\s*$/m);
@@ -216,28 +220,56 @@ export function splitTitle(markdown: string): { title: string; body: string } {
   };
 }
 
-export interface BlogPost {
+export interface PostFrontmatter {
   title: string;
-  description: string | null;
-  body_html: string;
-  slug: string;
+  description: string;
   published_at: null;
-  cover_image: null;
+  cover_image: string;
   status: "unpublished";
   tags: string[];
 }
 
+export interface BuiltPost {
+  slug: string;
+  title: string;
+  frontmatter: PostFrontmatter;
+  /** Complete `.mdx` file contents: frontmatter plus body. */
+  mdx: string;
+}
+
 /**
- * Builds the post payload for the site's importer.
+ * Escapes the two characters MDX treats as syntax.
  *
- * `status` is pinned to `unpublished`: the site treats published posts as
- * read-only and only builds published ones, so a draft is both revisable and
- * invisible until Thiago promotes it by hand. The agent never publishes live.
+ * Post bodies are HTML inside a `.mdx` file, and MDX reads a bare `{` as the
+ * start of a JSX expression and a stray `<` as the start of a tag. Either one
+ * fails the Gatsby build for the whole site, not just this post — so a code
+ * sample containing `{ }` or `a < b` has to be neutralised. HTML entities render
+ * identically and are inert to the MDX parser.
+ *
+ * Only text *outside* tags is touched; the tags `marked` emitted must survive.
  */
-export function buildBlogPost(
+export function escapeForMdx(html: string): string {
+  return html
+    .split(/(<[^>]*>)/)
+    .map((chunk, index) => (index % 2 === 1 ? chunk : chunk.replace(/[{}]/g, (c) => (c === "{" ? "&#123;" : "&#125;"))))
+    .join("");
+}
+
+/**
+ * Builds the `.mdx` file for a finished article.
+ *
+ * Frontmatter is serialised with gray-matter — the same library the blog's own
+ * `develop-tools/new-post.js` uses — so the output is byte-identical to a post
+ * scaffolded by hand rather than merely similar.
+ *
+ * `status` is pinned to `unpublished` and `published_at` to null. `gatsby build`
+ * only includes published posts, so the article stays invisible even after the
+ * pull request merges; promoting it is a separate, human action on the blog.
+ */
+export function buildPost(
   markdown: string,
-  options: { title?: string; description?: string; tags?: string[] } = {},
-): BlogPost {
+  options: { title?: string; description?: string; tags?: string[]; coverImage?: string } = {},
+): BuiltPost {
   const split = splitTitle(markdown);
   const title = (options.title ?? split.title).trim();
   if (!title) {
@@ -249,72 +281,60 @@ export function buildBlogPost(
   }
   // Keep the H1 only when the caller overrode the title, so no heading is lost.
   const body = options.title && split.title ? markdown.trim() : split.body;
-  return {
+  const frontmatter: PostFrontmatter = {
     title,
-    description: options.description?.trim() || null,
-    body_html: marked.parse(body, { async: false }) as string,
-    slug,
+    description: options.description?.trim() || "",
     published_at: null,
-    cover_image: null,
+    cover_image: options.coverImage ?? "",
     status: "unpublished",
     tags: options.tags ?? [],
   };
-}
-
-/** Test seam: the importer invocation, isolated so tests need not spawn node. */
-export type PostScriptRunner = (siteDir: string, jsonPath: string) => string;
-
-const defaultRunner: PostScriptRunner = (siteDir, jsonPath) =>
-  execFileSync("node", [BLOG_POST_SCRIPT, jsonPath], {
-    cwd: siteDir,
-    encoding: "utf-8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-let runPostScript: PostScriptRunner = defaultRunner;
-
-export function __setPostScriptRunner(runner: PostScriptRunner): void {
-  runPostScript = runner;
-}
-
-export function __resetPostScriptRunner(): void {
-  runPostScript = defaultRunner;
+  const html = escapeForMdx(marked.parse(body, { async: false }) as string);
+  return { slug, title, frontmatter, mdx: matter.stringify(`\n${html}\n`, frontmatter) };
 }
 
 /**
- * Hands an article to the blog by writing the importer's JSON and running it
- * inside the site checkout. Returns the message reported back to Pinky.
+ * Publishes a finished article to the blog as a pull request.
+ *
+ * Generates a cover image first (optional — a failure there costs the picture,
+ * not the article), then hands everything to the blog repo helper. Returns the
+ * sentence reported back to Pinky; never throws.
  */
-export function publishToBlog(
+export async function publishToBlog(
   markdown: string,
   options: { title?: string; description?: string; tags?: string[] } = {},
-): string {
-  const siteDir = config.blogSitePath;
-  if (!fs.existsSync(path.join(siteDir, BLOG_POST_SCRIPT))) {
-    return (
-      `Cannot reach the website: no ${BLOG_POST_SCRIPT} under ${siteDir}. ` +
-      `Set BLOG_SITE_PATH to a checkout of thiagocolen.github.io.`
-    );
+): Promise<string> {
+  let draft: BuiltPost;
+  try {
+    draft = buildPost(markdown, options);
+  } catch (e: any) {
+    return `Could not prepare the post: ${e.message}`;
   }
 
-  const post = buildBlogPost(markdown, options);
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brain-post-"));
-  const jsonPath = path.join(tmpDir, `${post.slug}.json`);
+  const image = await generateCoverImage(draft.title, options.description);
+  // Rebuild once the image path is known, so the frontmatter carries the cover.
+  const post = image
+    ? buildPost(markdown, { ...options, coverImage: coverImagePath(draft.slug, image.extension) })
+    : draft;
+
   try {
-    fs.writeFileSync(jsonPath, JSON.stringify(post, null, 2), "utf-8");
-    const output = runPostScript(siteDir, jsonPath);
-    logger.info(`[Tools] Published "${post.title}" to the blog as a draft`);
+    const { prUrl, imageIncluded } = publishArticleAsPullRequest({
+      slug: post.slug,
+      title: post.title,
+      mdx: post.mdx,
+      image: image ? { bytes: image.bytes, extension: image.extension } : null,
+    });
+    logger.info(`[Tools] Opened a pull request for "${post.title}": ${prUrl}`);
     return (
-      `Published "${post.title}" to thiagocolen.github.io as a draft post ` +
-      `(slug: ${post.slug}, status: unpublished). It stays invisible on the live ` +
-      `site until it is promoted to "published" there.\n\n${String(output).trim()}`
+      `Opened a pull request on thiagocolen.github.io for "${post.title}": ${prUrl}\n\n` +
+      `It adds content/posts/${post.slug}.mdx with status "unpublished"` +
+      `${imageIncluded ? ", plus a generated cover image" : " (no cover image — generation was unavailable)"}. ` +
+      `The article is NOT live and NOT merged: it is a draft awaiting review, and even once ` +
+      `merged it stays invisible on the site until it is promoted there by hand.`
     );
   } catch (e: any) {
-    const detail = [e?.stderr, e?.stdout, e?.message].filter(Boolean).map(String).join("\n").trim();
-    logger.error(`[Tools] Blog publish failed: ${detail}`);
-    return `Failed to publish to the website: ${detail}`;
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    logger.error(`[Tools] Blog publish failed: ${e.message}`);
+    return `Failed to publish to the website: ${e.message}`;
   }
 }
 
@@ -461,7 +481,7 @@ const publishArticle = tool(
       return `No article exists at ${source}. Save it first, then publish.`;
     }
     try {
-      return publishToBlog(fs.readFileSync(source, "utf-8"), { description, tags });
+      return await publishToBlog(fs.readFileSync(source, "utf-8"), { description, tags });
     } catch (e: any) {
       return `Could not publish: ${e.message}`;
     }
@@ -469,7 +489,7 @@ const publishArticle = tool(
   {
     name: "publish_article",
     description:
-      "Publish a saved article to the thiagocolen.github.io blog. It lands as a DRAFT (status 'unpublished'), so it is not live until Thiago promotes it on the site. Only call this after Pinky explicitly asks to publish.",
+      "Publish a saved article to the thiagocolen.github.io blog by opening a PULL REQUEST: it generates a cover image, then commits the post on a new branch and opens a PR for review. Returns the PR URL. The post is a DRAFT (status 'unpublished') — it is not live, and merging the PR still does not publish it. Only call this after Pinky explicitly asks to publish.",
     schema: z.object({
       filename: z.string().describe("Filename of the saved article, e.g. 'game-of-life.md'."),
       description: z

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -1,8 +1,12 @@
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import fs from "fs";
+import os from "os";
 import path from "path";
+import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
+import { marked } from "marked";
+import { config } from "../config.js";
 import { logger } from "../utils/logger.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -175,6 +179,154 @@ export function resolveArticlePath(filename: string): string {
   return path.join(ARTICLES_DIR, safe);
 }
 
+/**
+ * Delivery of a finished article.
+ *
+ * Two destinations, chosen by Pinky once the article is done:
+ *  - the blog at thiagocolen.github.io, via that site's own tooling; or
+ *  - any folder on this machine.
+ */
+
+/** Path, relative to the site checkout, of the script that ingests posts. */
+export const BLOG_POST_SCRIPT = path.join("develop-tools", "add-posts-from-json.js");
+
+/** Reduces a title to the `^[a-z0-9]+(-[a-z0-9]+)*$` slug the site's script demands. */
+export function slugify(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/['\u2019]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Splits the leading `# Title` off an article.
+ *
+ * The site renders the title itself from the `title` column, so leaving the H1
+ * in `body_html` would show it twice.
+ */
+export function splitTitle(markdown: string): { title: string; body: string } {
+  const match = markdown.match(/^\s*#\s+(.+?)\s*$/m);
+  if (!match) return { title: "", body: markdown.trim() };
+  return {
+    title: match[1].trim(),
+    body: markdown.slice(match.index! + match[0].length).trim(),
+  };
+}
+
+export interface BlogPost {
+  title: string;
+  description: string | null;
+  body_html: string;
+  slug: string;
+  published_at: null;
+  cover_image: null;
+  status: "unpublished";
+  tags: string[];
+}
+
+/**
+ * Builds the post payload for the site's importer.
+ *
+ * `status` is pinned to `unpublished`: the site treats published posts as
+ * read-only and only builds published ones, so a draft is both revisable and
+ * invisible until Thiago promotes it by hand. The agent never publishes live.
+ */
+export function buildBlogPost(
+  markdown: string,
+  options: { title?: string; description?: string; tags?: string[] } = {},
+): BlogPost {
+  const split = splitTitle(markdown);
+  const title = (options.title ?? split.title).trim();
+  if (!title) {
+    throw new Error("Cannot derive a post title: pass one, or start the article with '# Title'.");
+  }
+  const slug = slugify(title);
+  if (!slug) {
+    throw new Error(`Title "${title}" produces an empty slug — it needs letters or digits.`);
+  }
+  // Keep the H1 only when the caller overrode the title, so no heading is lost.
+  const body = options.title && split.title ? markdown.trim() : split.body;
+  return {
+    title,
+    description: options.description?.trim() || null,
+    body_html: marked.parse(body, { async: false }) as string,
+    slug,
+    published_at: null,
+    cover_image: null,
+    status: "unpublished",
+    tags: options.tags ?? [],
+  };
+}
+
+/** Test seam: the importer invocation, isolated so tests need not spawn node. */
+export type PostScriptRunner = (siteDir: string, jsonPath: string) => string;
+
+const defaultRunner: PostScriptRunner = (siteDir, jsonPath) =>
+  execFileSync("node", [BLOG_POST_SCRIPT, jsonPath], {
+    cwd: siteDir,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+let runPostScript: PostScriptRunner = defaultRunner;
+
+export function __setPostScriptRunner(runner: PostScriptRunner): void {
+  runPostScript = runner;
+}
+
+export function __resetPostScriptRunner(): void {
+  runPostScript = defaultRunner;
+}
+
+/**
+ * Hands an article to the blog by writing the importer's JSON and running it
+ * inside the site checkout. Returns the message reported back to Pinky.
+ */
+export function publishToBlog(
+  markdown: string,
+  options: { title?: string; description?: string; tags?: string[] } = {},
+): string {
+  const siteDir = config.blogSitePath;
+  if (!fs.existsSync(path.join(siteDir, BLOG_POST_SCRIPT))) {
+    return (
+      `Cannot reach the website: no ${BLOG_POST_SCRIPT} under ${siteDir}. ` +
+      `Set BLOG_SITE_PATH to a checkout of thiagocolen.github.io.`
+    );
+  }
+
+  const post = buildBlogPost(markdown, options);
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brain-post-"));
+  const jsonPath = path.join(tmpDir, `${post.slug}.json`);
+  try {
+    fs.writeFileSync(jsonPath, JSON.stringify(post, null, 2), "utf-8");
+    const output = runPostScript(siteDir, jsonPath);
+    logger.info(`[Tools] Published "${post.title}" to the blog as a draft`);
+    return (
+      `Published "${post.title}" to thiagocolen.github.io as a draft post ` +
+      `(slug: ${post.slug}, status: unpublished). It stays invisible on the live ` +
+      `site until it is promoted to "published" there.\n\n${String(output).trim()}`
+    );
+  } catch (e: any) {
+    const detail = [e?.stderr, e?.stdout, e?.message].filter(Boolean).map(String).join("\n").trim();
+    logger.error(`[Tools] Blog publish failed: ${detail}`);
+    return `Failed to publish to the website: ${detail}`;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+/** Resolves a destination inside a Pinky-supplied folder, keeping the filename flat. */
+export function resolveExportPath(folder: string, filename: string): string {
+  // Callback form: a home directory containing "$" must not be read as a
+  // replacement pattern.
+  const expanded = folder.trim().replace(/^~(?=[\\/]|$)/, () => os.homedir());
+  const dir = path.resolve(process.cwd(), expanded);
+  return path.join(dir, path.basename(resolveArticlePath(filename)));
+}
+
 const listTopics = tool(
   async () => {
     const store = loadVectorStore();
@@ -294,6 +446,73 @@ const readArticle = tool(
   },
 );
 
+const publishArticle = tool(
+  async ({
+    filename,
+    description,
+    tags,
+  }: {
+    filename: string;
+    description?: string;
+    tags?: string[];
+  }) => {
+    const source = resolveArticlePath(filename);
+    if (!fs.existsSync(source)) {
+      return `No article exists at ${source}. Save it first, then publish.`;
+    }
+    try {
+      return publishToBlog(fs.readFileSync(source, "utf-8"), { description, tags });
+    } catch (e: any) {
+      return `Could not publish: ${e.message}`;
+    }
+  },
+  {
+    name: "publish_article",
+    description:
+      "Publish a saved article to the thiagocolen.github.io blog. It lands as a DRAFT (status 'unpublished'), so it is not live until Thiago promotes it on the site. Only call this after Pinky explicitly asks to publish.",
+    schema: z.object({
+      filename: z.string().describe("Filename of the saved article, e.g. 'game-of-life.md'."),
+      description: z
+        .string()
+        .optional()
+        .describe("One-sentence summary shown in the blog's post listing."),
+      tags: z
+        .array(z.string())
+        .optional()
+        .describe("Lowercase topic tags, e.g. ['cellular-automata', 'complexity']."),
+    }),
+  },
+);
+
+const exportArticle = tool(
+  async ({ filename, folder }: { filename: string; folder: string }) => {
+    const source = resolveArticlePath(filename);
+    if (!fs.existsSync(source)) {
+      return `No article exists at ${source}. Save it first, then copy it.`;
+    }
+    try {
+      const target = resolveExportPath(folder, filename);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.copyFileSync(source, target);
+      logger.info(`[Tools] Article exported to ${target}`);
+      return `Article saved to ${target}`;
+    } catch (e: any) {
+      return `Could not save the article to "${folder}": ${e.message}`;
+    }
+  },
+  {
+    name: "export_article",
+    description:
+      "Copy a saved article into a folder Pinky names. Returns the absolute path — always report that exact path to Pinky.",
+    schema: z.object({
+      filename: z.string().describe("Filename of the saved article, e.g. 'game-of-life.md'."),
+      folder: z
+        .string()
+        .describe("Destination folder Pinky provided, absolute or relative. Created if missing."),
+    }),
+  },
+);
+
 export const brainTools = [
   listTopics,
   listSubtopics,
@@ -301,4 +520,6 @@ export const brainTools = [
   saveArticle,
   updateArticle,
   readArticle,
+  publishArticle,
+  exportArticle,
 ];

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,9 +57,18 @@ const ConfigSchema = z.object({
   langchainTracingV2: z.boolean().default(false),
   langchainApiKey: z.string().default(""),
   langchainProject: z.string().default("pinky-and-the-brain-agents"),
-  // Checkout of https://github.com/thiagocolen/thiagocolen.github.io, whose
-  // develop-tools/add-posts-from-json.js script is how articles reach the blog.
-  blogSitePath: z.string().default(path.resolve(rootDir, "../thiagocolen.github.io")),
+  // The blog is a separate repository. Articles reach it as pull requests, so
+  // what we need is a clone URL rather than a path on this machine.
+  blogRepoUrl: z.string().default("https://github.com/thiagocolen/thiagocolen.github.io.git"),
+  // Base branch for those pull requests. NOT the repo's default branch: `master`
+  // still carries the retired SQLite pipeline and has no content/posts/, so an
+  // .mdx file merged there would never render. Note the sibling branch
+  // `release-v120` (no slashes) is the *old* one — these are different branches.
+  blogBaseBranch: z.string().default("release/v1.2.0"),
+  // Cover-image generation. Optional: without a key the article still publishes,
+  // just without an image. The text model stays Anthropic; this is images only.
+  geminiApiKey: z.string().default(""),
+  geminiImageModel: z.string().default("gemini-3.1-flash-lite-image"),
 });
 
 export type AppConfig = z.infer<typeof ConfigSchema>;
@@ -75,7 +84,10 @@ const rawConfig = {
   langchainTracingV2: process.env.LANGCHAIN_TRACING_V2 === "true" || process.env.LANGSMITH_TRACING === "true",
   langchainApiKey: process.env.LANGCHAIN_API_KEY || process.env.LANGSMITH_API_KEY,
   langchainProject: process.env.LANGCHAIN_PROJECT || process.env.LANGSMITH_PROJECT,
-  blogSitePath: process.env.BLOG_SITE_PATH,
+  blogRepoUrl: process.env.BLOG_REPO_URL,
+  blogBaseBranch: process.env.BLOG_BASE_BRANCH,
+  geminiApiKey: process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY,
+  geminiImageModel: process.env.GEMINI_IMAGE_MODEL,
 };
 
 let validatedConfig: AppConfig;

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,9 @@ const ConfigSchema = z.object({
   langchainTracingV2: z.boolean().default(false),
   langchainApiKey: z.string().default(""),
   langchainProject: z.string().default("pinky-and-the-brain-agents"),
+  // Checkout of https://github.com/thiagocolen/thiagocolen.github.io, whose
+  // develop-tools/add-posts-from-json.js script is how articles reach the blog.
+  blogSitePath: z.string().default(path.resolve(rootDir, "../thiagocolen.github.io")),
 });
 
 export type AppConfig = z.infer<typeof ConfigSchema>;
@@ -72,6 +75,7 @@ const rawConfig = {
   langchainTracingV2: process.env.LANGCHAIN_TRACING_V2 === "true" || process.env.LANGSMITH_TRACING === "true",
   langchainApiKey: process.env.LANGCHAIN_API_KEY || process.env.LANGSMITH_API_KEY,
   langchainProject: process.env.LANGCHAIN_PROJECT || process.env.LANGSMITH_PROJECT,
+  blogSitePath: process.env.BLOG_SITE_PATH,
 };
 
 let validatedConfig: AppConfig;
@@ -91,11 +95,23 @@ export function validateApiKey(key: string): boolean {
   return key === config.patbaApiKey;
 }
 
-export function validateConfig() {
+export interface ValidateConfigOptions {
+  /**
+   * Whether PATBA_API_KEY is required. It authenticates callers of the REST API
+   * (`validateApiKey`), so only the HTTP entrypoint genuinely needs it. Local
+   * stdio entrypoints talk to a client that already has OS-level access to this
+   * process, and demanding the key there turns an unused secret into a hard
+   * startup dependency — which is exactly what MCP clients trip over, since
+   * they spawn servers with a filtered environment rather than the full one.
+   */
+  requirePatbaApiKey?: boolean;
+}
+
+export function validateConfig({ requirePatbaApiKey = true }: ValidateConfigOptions = {}) {
   if (!config.anthropicApiKey) {
     throw new Error("Missing critical environment variable: ANTHROPIC_API_KEY must be provided");
   }
-  if (!config.patbaApiKey) {
+  if (requirePatbaApiKey && !config.patbaApiKey) {
     throw new Error("Missing critical environment variable: PATBA_API_KEY (or API_KEY / AWS_APP_API_KEY) must be provided");
   }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -5,12 +5,16 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { runGraphWorkflow } from "./agents/graph.js";
+import { resolveThreadId } from "./utils/session.js";
 import { isAIMessage, getMessageContent } from "./utils/messages.js";
 import { logger } from "./utils/logger.js";
 import { validateConfig } from "./config.js";
 
 try {
-  validateConfig();
+  // PATBA_API_KEY guards the REST API, which this entrypoint does not serve.
+  // MCP clients spawn servers with a filtered environment, so requiring an
+  // unused secret here would fail startup for no security benefit.
+  validateConfig({ requirePatbaApiKey: false });
 } catch (e: any) {
   console.error("Configuration validation failed:", e.message);
   process.exit(1);
@@ -34,22 +38,29 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: "run_agent",
-        description: "Executes the multi-agent graph supervisor workflow with a specific prompt. Returns the final generated output.",
+        description:
+          "Send one message to The Brain, a guided tutor that teaches technical topics and writes articles. " +
+          "This is a MULTI-TURN conversation, not a one-shot query: The Brain leads a journey (choose a topic → " +
+          "choose a subtopic → learn it or write an article about it) and ends every reply with a question. " +
+          "Call this repeatedly, relaying the user's answer each time, to carry that conversation forward. " +
+          "Start with a greeting such as 'hello' to receive the topic menu.",
         inputSchema: {
           type: "object",
           properties: {
             prompt: {
               type: "string",
-              description: "The instruction or query for the agent workspace (e.g., 'Write an article about CDNs' or 'Explain CDNs').",
+              description: "The next message for The Brain — a greeting, a menu choice ('2'), an answer to its question, or an instruction.",
             },
             agentName: {
               type: "string",
-              description: "The agent node to invoke. Defaults to 'the-brain'. Can also be 'brain' or 'supervisor' for compatibility.",
-              enum: ["the-brain", "brain", "supervisor", "developer", "writer", "instructor", "specialist", "publisher"],
+              description: "The agent to invoke. Defaults to 'the-brain'; 'brain' and 'supervisor' are accepted aliases.",
+              enum: ["the-brain", "brain", "supervisor"],
             },
             threadId: {
               type: "string",
-              description: "Optional persistent thread ID to isolate states across runs. If not provided, a random one will be generated.",
+              description:
+                "Optional. Omit this — by default all calls share one conversation, which is what lets the journey progress. " +
+                "Pass an id only to deliberately start or resume a separate, isolated conversation.",
             },
           },
           required: ["prompt"],
@@ -68,7 +79,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const args = request.params.arguments as any;
   const prompt = args.prompt;
   const agentName = args.agentName || "the-brain";
-  const threadId = args.threadId || `mcp-session-${Math.random().toString(36).substring(7)}`;
+  const threadId = resolveThreadId(args.threadId);
 
   try {
     const result = await runGraphWorkflow(agentName, prompt, threadId, (progress) => {

--- a/src/tests/unit/brain.test.ts
+++ b/src/tests/unit/brain.test.ts
@@ -8,6 +8,7 @@ vi.mock("../../config.js", () => ({
     anthropicApiKey: "mock-key-for-testing",
     anthropicModel: "claude-sonnet-5",
     patbaApiKey: "mock-key-for-testing",
+    blogSitePath: "/nonexistent-site-checkout-for-tests",
   },
   projectRoot: process.cwd(),
 }));

--- a/src/tests/unit/brain.test.ts
+++ b/src/tests/unit/brain.test.ts
@@ -8,7 +8,10 @@ vi.mock("../../config.js", () => ({
     anthropicApiKey: "mock-key-for-testing",
     anthropicModel: "claude-sonnet-5",
     patbaApiKey: "mock-key-for-testing",
-    blogSitePath: "/nonexistent-site-checkout-for-tests",
+    blogRepoUrl: "https://example.invalid/blog.git",
+    blogBaseBranch: "release/v1.2.0",
+    geminiApiKey: "",
+    geminiImageModel: "gemini-3.1-flash-lite-image",
   },
   projectRoot: process.cwd(),
 }));

--- a/src/tests/unit/mcp.test.ts
+++ b/src/tests/unit/mcp.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+
+// `src/mcp.ts` cannot be imported here — it calls validateConfig() and opens a
+// stdio transport at module load. The thread logic lives in its own module for
+// exactly that reason.
+import { MCP_SESSION_THREAD_ID, resolveThreadId } from "../../utils/session.js";
+
+describe("MCP_SESSION_THREAD_ID", () => {
+  it("follows the entrypoint's thread-naming convention", () => {
+    expect(MCP_SESSION_THREAD_ID).toMatch(/^mcp-session-/);
+  });
+
+  it("is long enough not to collide between concurrent server processes", () => {
+    // All entrypoints share one state.db keyed only by thread id, so a short
+    // id would let two servers land in each other's conversation.
+    expect(MCP_SESSION_THREAD_ID.replace("mcp-session-", "").length).toBeGreaterThanOrEqual(32);
+  });
+});
+
+describe("validateConfig — PATBA_API_KEY requirement", () => {
+  /**
+   * Loads config.js against a controlled environment. dotenv is stubbed out so
+   * the developer's real .env cannot leak keys into these assertions.
+   */
+  const loadConfig = async (env: Record<string, string | undefined>) => {
+    vi.resetModules();
+    vi.doMock("dotenv", () => ({ default: { config: () => ({ parsed: {} }) } }));
+    const saved = { ...process.env };
+    for (const key of ["ANTHROPIC_API_KEY", "PATBA_API_KEY", "API_KEY", "AWS_APP_API_KEY"]) {
+      delete process.env[key];
+    }
+    Object.assign(process.env, env);
+    try {
+      return await import("../../config.js");
+    } finally {
+      process.env = saved;
+      vi.doUnmock("dotenv");
+    }
+  };
+
+  it("still requires the key by default, for the REST entrypoint", async () => {
+    const { validateConfig } = await loadConfig({ ANTHROPIC_API_KEY: "sk-test" });
+    expect(() => validateConfig()).toThrow(/PATBA_API_KEY/);
+  });
+
+  it("does not require it when the caller opts out", async () => {
+    // The MCP entrypoint serves no HTTP surface, so the key is dead weight —
+    // and MCP clients spawn servers with a filtered environment that would
+    // drop it anyway.
+    const { validateConfig } = await loadConfig({ ANTHROPIC_API_KEY: "sk-test" });
+    expect(() => validateConfig({ requirePatbaApiKey: false })).not.toThrow();
+  });
+
+  it("still requires ANTHROPIC_API_KEY when opted out", async () => {
+    const { validateConfig } = await loadConfig({ PATBA_API_KEY: "secret" });
+    expect(() => validateConfig({ requirePatbaApiKey: false })).toThrow(/ANTHROPIC_API_KEY/);
+  });
+});
+
+describe("resolveThreadId", () => {
+  it("returns the same thread across calls so the journey advances", () => {
+    // The regression this guards: a per-call random id stranded every MCP
+    // conversation on step one of the journey.
+    expect(resolveThreadId()).toBe(resolveThreadId());
+    expect(resolveThreadId()).toBe(MCP_SESSION_THREAD_ID);
+  });
+
+  it("lets an explicit id branch into a separate conversation", () => {
+    expect(resolveThreadId("article-drafting")).toBe("article-drafting");
+  });
+
+  it("trims a padded id rather than treating it as a distinct thread", () => {
+    expect(resolveThreadId("  article-drafting  ")).toBe("article-drafting");
+  });
+
+  it("falls back to the process thread for blank input", () => {
+    for (const blank of [undefined, "", "   ", "\n\t"]) {
+      expect(resolveThreadId(blank), `blank input ${JSON.stringify(blank)}`).toBe(
+        MCP_SESSION_THREAD_ID,
+      );
+    }
+  });
+});

--- a/src/tests/unit/publishing.test.ts
+++ b/src/tests/unit/publishing.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+// Mutable so each test can point the agent at a different (or missing) checkout
+// of thiagocolen.github.io. `vi.hoisted` because vi.mock's factory is lifted
+// above this file's own declarations.
+const mockConfig = vi.hoisted(() => ({
+  anthropicApiKey: "mock-key-for-testing",
+  anthropicModel: "claude-sonnet-5",
+  patbaApiKey: "mock-key-for-testing",
+  blogSitePath: "/nonexistent-site-checkout-for-tests",
+}));
+
+vi.mock("../../config.js", () => ({
+  config: mockConfig,
+  projectRoot: process.cwd(),
+}));
+
+import {
+  slugify,
+  splitTitle,
+  buildBlogPost,
+  publishToBlog,
+  resolveExportPath,
+  BLOG_POST_SCRIPT,
+  __setPostScriptRunner,
+  __resetPostScriptRunner,
+} from "../../agents/tools.js";
+import { BRAIN_SYSTEM_PROMPT } from "../../agents/prompts.js";
+
+/** The slug pattern add-posts-from-json.js validates against. */
+const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+describe("slugify", () => {
+  it("produces slugs the site's importer accepts", () => {
+    for (const title of [
+      "Conway's Game of Life",
+      "AWS  —  Cloud Practitioner (CLF-C02)!",
+      "React 19: what's new?",
+    ]) {
+      expect(slugify(title)).toMatch(SLUG_PATTERN);
+    }
+  });
+
+  it("folds accents rather than dropping the letters", () => {
+    expect(slugify("Autômatos Celulares")).toBe("automatos-celulares");
+  });
+
+  it("collapses separators and trims the edges", () => {
+    expect(slugify("  --Hello___World--  ")).toBe("hello-world");
+  });
+
+  it("returns an empty string when nothing sluggable remains", () => {
+    expect(slugify("!!! ???")).toBe("");
+  });
+});
+
+describe("splitTitle", () => {
+  it("splits the leading H1 off the body", () => {
+    const { title, body } = splitTitle("# Game of Life\n\nCells live and die.");
+    expect(title).toBe("Game of Life");
+    expect(body).toBe("Cells live and die.");
+  });
+
+  it("leaves the markdown intact when there is no H1", () => {
+    const { title, body } = splitTitle("Just a paragraph.");
+    expect(title).toBe("");
+    expect(body).toBe("Just a paragraph.");
+  });
+
+  it("does not mistake an H2 for the title", () => {
+    expect(splitTitle("## Subheading\n\nText.").title).toBe("");
+  });
+});
+
+describe("buildBlogPost", () => {
+  const article = "# Game of Life\n\nA **cellular automaton**.\n\nSecond paragraph.";
+
+  it("derives the title and slug from the H1", () => {
+    const post = buildBlogPost(article);
+    expect(post.title).toBe("Game of Life");
+    expect(post.slug).toBe("game-of-life");
+  });
+
+  it("renders the body as HTML without repeating the title", () => {
+    const post = buildBlogPost(article);
+    expect(post.body_html).toContain("<strong>cellular automaton</strong>");
+    expect(post.body_html).toContain("Second paragraph.");
+    expect(post.body_html).not.toContain("Game of Life");
+  });
+
+  it("always produces a draft with no publish date", () => {
+    const post = buildBlogPost(article);
+    expect(post.status).toBe("unpublished");
+    expect(post.published_at).toBeNull();
+  });
+
+  it("defaults description and tags to the importer's empty values", () => {
+    const post = buildBlogPost(article);
+    expect(post.description).toBeNull();
+    expect(post.tags).toEqual([]);
+  });
+
+  it("carries the description and tags through", () => {
+    const post = buildBlogPost(article, {
+      description: "  A short summary.  ",
+      tags: ["cellular-automata"],
+    });
+    expect(post.description).toBe("A short summary.");
+    expect(post.tags).toEqual(["cellular-automata"]);
+  });
+
+  it("keeps the H1 in the body when the title is overridden", () => {
+    const post = buildBlogPost(article, { title: "Conway's Automaton" });
+    expect(post.title).toBe("Conway's Automaton");
+    expect(post.slug).toBe("conways-automaton");
+    expect(post.body_html).toContain("Game of Life");
+  });
+
+  it("refuses an article with no derivable title", () => {
+    expect(() => buildBlogPost("Just prose, no heading.")).toThrow(/title/i);
+  });
+
+  it("refuses a title that cannot produce a valid slug", () => {
+    expect(() => buildBlogPost("# ???")).toThrow(/slug/i);
+  });
+});
+
+describe("publishToBlog", () => {
+  let siteDir: string;
+
+  /** Stands up a fake thiagocolen.github.io checkout containing the importer. */
+  const createSiteCheckout = () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "brain-site-"));
+    const script = path.join(dir, BLOG_POST_SCRIPT);
+    fs.mkdirSync(path.dirname(script), { recursive: true });
+    fs.writeFileSync(script, "// stand-in for the real importer\n");
+    return dir;
+  };
+
+  beforeEach(() => {
+    siteDir = createSiteCheckout();
+    mockConfig.blogSitePath = siteDir;
+  });
+
+  afterEach(() => {
+    __resetPostScriptRunner();
+    fs.rmSync(siteDir, { recursive: true, force: true });
+    mockConfig.blogSitePath = "/nonexistent-site-checkout-for-tests";
+  });
+
+  it("runs the site's importer against the post JSON it wrote", () => {
+    let seen: { siteDir: string; payload: any } | undefined;
+    __setPostScriptRunner((dir, jsonPath) => {
+      seen = { siteDir: dir, payload: JSON.parse(fs.readFileSync(jsonPath, "utf-8")) };
+      return "✓ Added";
+    });
+
+    const result = publishToBlog("# Game of Life\n\nCells.", {
+      description: "About automata.",
+      tags: ["complexity"],
+    });
+
+    expect(seen!.siteDir).toBe(siteDir);
+    expect(seen!.payload).toMatchObject({
+      title: "Game of Life",
+      slug: "game-of-life",
+      status: "unpublished",
+      published_at: null,
+      description: "About automata.",
+      tags: ["complexity"],
+    });
+    expect(result).toContain("game-of-life");
+  });
+
+  it("tells Pinky the post is a draft, never that it is live", () => {
+    __setPostScriptRunner(() => "✓ Added");
+    const result = publishToBlog("# Game of Life\n\nCells.");
+    expect(result).toMatch(/draft/i);
+    expect(result).toContain("unpublished");
+  });
+
+  it("removes the temporary JSON once the importer has run", () => {
+    let jsonPath = "";
+    __setPostScriptRunner((_dir, file) => {
+      jsonPath = file;
+      return "✓ Added";
+    });
+    publishToBlog("# Game of Life\n\nCells.");
+    expect(fs.existsSync(jsonPath)).toBe(false);
+  });
+
+  it("cleans up even when the importer fails", () => {
+    let jsonPath = "";
+    __setPostScriptRunner((_dir, file) => {
+      jsonPath = file;
+      throw Object.assign(new Error("Command failed"), { stderr: "slug already published" });
+    });
+    const result = publishToBlog("# Game of Life\n\nCells.");
+    expect(result).toMatch(/^Failed to publish/);
+    expect(result).toContain("slug already published");
+    expect(fs.existsSync(jsonPath)).toBe(false);
+  });
+
+  it("explains how to fix a missing site checkout instead of throwing", () => {
+    mockConfig.blogSitePath = path.join(os.tmpdir(), "definitely-not-a-checkout");
+    __setPostScriptRunner(() => {
+      throw new Error("the importer must not run without a checkout");
+    });
+    const result = publishToBlog("# Game of Life\n\nCells.");
+    expect(result).toContain("BLOG_SITE_PATH");
+  });
+});
+
+describe("resolveExportPath", () => {
+  it("places the article inside the folder Pinky named", () => {
+    const target = resolveExportPath(path.join(os.tmpdir(), "pinky-out"), "game-of-life.md");
+    expect(path.dirname(target)).toBe(path.join(os.tmpdir(), "pinky-out"));
+    expect(path.basename(target)).toBe("game-of-life.md");
+  });
+
+  it("resolves a relative folder against the working directory", () => {
+    expect(resolveExportPath("out/articles", "a.md")).toBe(
+      path.join(process.cwd(), "out", "articles", "a.md"),
+    );
+  });
+
+  it("keeps a traversing filename inside the destination folder", () => {
+    const dest = path.join(os.tmpdir(), "pinky-out");
+    const target = resolveExportPath(dest, "../../etc/passwd");
+    expect(path.dirname(target)).toBe(dest);
+    expect(path.basename(target)).toBe("passwd.md");
+  });
+
+  it("appends .md to an extensionless name", () => {
+    expect(path.basename(resolveExportPath("out", "Game of Life"))).toBe("Game-of-Life.md");
+  });
+});
+
+describe("Delivery tools", () => {
+  let tmpDir: string;
+  let cwdSpy: any;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brain-delivery-"));
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    __resetPostScriptRunner();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const getTool = async (name: string) => {
+    const { brainTools } = await import("../../agents/tools.js");
+    return brainTools.find((t: any) => t.name === name)!;
+  };
+
+  it("exposes both delivery tools to the agent", async () => {
+    const { brainTools } = await import("../../agents/tools.js");
+    const names = brainTools.map((t: any) => t.name);
+    expect(names).toContain("publish_article");
+    expect(names).toContain("export_article");
+  });
+
+  it("copies an article into a folder and reports the path", async () => {
+    const saveArticle = await getTool("save_article");
+    const saved: any = await saveArticle.invoke({
+      filename: "delivery-test.md",
+      content: "# Delivery\n\nBody.",
+    });
+    const savedPath = String(saved).replace("Article saved to ", "");
+
+    const destination = path.join(tmpDir, "nested", "exports");
+    const exportArticle = await getTool("export_article");
+    const result: any = await exportArticle.invoke({
+      filename: "delivery-test.md",
+      folder: destination,
+    });
+
+    const reportedPath = String(result).replace("Article saved to ", "");
+    expect(path.dirname(reportedPath)).toBe(destination);
+    expect(fs.readFileSync(reportedPath, "utf-8")).toContain("# Delivery");
+    fs.rmSync(savedPath, { force: true });
+  });
+
+  it("refuses to export an article that was never saved", async () => {
+    const exportArticle = await getTool("export_article");
+    const result: any = await exportArticle.invoke({
+      filename: "never-written.md",
+      folder: tmpDir,
+    });
+    expect(String(result)).toContain("No article exists");
+  });
+
+  it("refuses to publish an article that was never saved", async () => {
+    __setPostScriptRunner(() => {
+      throw new Error("must not reach the importer");
+    });
+    const publishArticle = await getTool("publish_article");
+    const result: any = await publishArticle.invoke({ filename: "never-written.md" });
+    expect(String(result)).toContain("No article exists");
+  });
+});
+
+describe("Delivery instructions in the system prompt", () => {
+  it("offers both destinations once an article is finished", () => {
+    expect(BRAIN_SYSTEM_PROMPT).toContain("publish_article");
+    expect(BRAIN_SYSTEM_PROMPT).toContain("export_article");
+    expect(BRAIN_SYSTEM_PROMPT).toContain("thiagocolen.github.io");
+  });
+
+  it("requires Pinky to choose before anything leaves the conversation", () => {
+    expect(BRAIN_SYSTEM_PROMPT).toMatch(/never on your own initiative/i);
+    expect(BRAIN_SYSTEM_PROMPT).toMatch(/Never claim an article is live/i);
+  });
+});

--- a/src/tests/unit/publishing.test.ts
+++ b/src/tests/unit/publishing.test.ts
@@ -2,15 +2,19 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import matter from "gray-matter";
 
-// Mutable so each test can point the agent at a different (or missing) checkout
-// of thiagocolen.github.io. `vi.hoisted` because vi.mock's factory is lifted
-// above this file's own declarations.
+// Mutable so each test can vary what the agent believes about the blog repo and
+// whether an image key is configured. `vi.hoisted` because vi.mock's factory is
+// lifted above this file's own declarations.
 const mockConfig = vi.hoisted(() => ({
   anthropicApiKey: "mock-key-for-testing",
   anthropicModel: "claude-sonnet-5",
   patbaApiKey: "mock-key-for-testing",
-  blogSitePath: "/nonexistent-site-checkout-for-tests",
+  blogRepoUrl: "https://github.com/thiagocolen/thiagocolen.github.io.git",
+  blogBaseBranch: "release/v1.2.0",
+  geminiApiKey: "",
+  geminiImageModel: "gemini-3.1-flash-lite-image",
 }));
 
 vi.mock("../../config.js", () => ({
@@ -21,20 +25,34 @@ vi.mock("../../config.js", () => ({
 import {
   slugify,
   splitTitle,
-  buildBlogPost,
+  buildPost,
+  escapeForMdx,
   publishToBlog,
   resolveExportPath,
-  BLOG_POST_SCRIPT,
-  __setPostScriptRunner,
-  __resetPostScriptRunner,
 } from "../../agents/tools.js";
+import {
+  articleBranch,
+  coverImagePath,
+  redactSecrets,
+  POSTS_DIR,
+  IMAGES_DIR,
+  __setCommandRunner,
+  __resetCommandRunner,
+} from "../../utils/blog-repo.js";
+import {
+  buildImagePrompt,
+  extensionFor,
+  generateCoverImage,
+  __setImageGenerator,
+  __resetImageGenerator,
+} from "../../utils/image-gen.js";
 import { BRAIN_SYSTEM_PROMPT } from "../../agents/prompts.js";
 
-/** The slug pattern add-posts-from-json.js validates against. */
+/** Slug shape the blog's own tooling produces, and its URLs depend on. */
 const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 describe("slugify", () => {
-  it("produces slugs the site's importer accepts", () => {
+  it("produces slugs matching the blog's URL shape", () => {
     for (const title of [
       "Conway's Game of Life",
       "AWS  —  Cloud Practitioner (CLF-C02)!",
@@ -44,8 +62,10 @@ describe("slugify", () => {
     }
   });
 
-  it("folds accents rather than dropping the letters", () => {
-    expect(slugify("Autômatos Celulares")).toBe("automatos-celulares");
+  it("matches develop-tools/new-post.js exactly, apostrophes included", () => {
+    // The blog's script does not strip apostrophes, so neither do we — a slug
+    // that disagrees with the site's own tool would produce a different URL.
+    expect(slugify("Conway's Game")).toBe("conway-s-game");
   });
 
   it("collapses separators and trims the edges", () => {
@@ -58,184 +78,351 @@ describe("slugify", () => {
 });
 
 describe("splitTitle", () => {
-  it("splits the leading H1 off the body", () => {
-    const { title, body } = splitTitle("# Game of Life\n\nCells live and die.");
-    expect(title).toBe("Game of Life");
-    expect(body).toBe("Cells live and die.");
+  it("lifts the H1 out of the body", () => {
+    const { title, body } = splitTitle("# The Title\n\nFirst paragraph.");
+    expect(title).toBe("The Title");
+    expect(body).toBe("First paragraph.");
   });
 
-  it("leaves the markdown intact when there is no H1", () => {
-    const { title, body } = splitTitle("Just a paragraph.");
+  it("leaves the text alone when there is no H1", () => {
+    const { title, body } = splitTitle("Just prose.");
     expect(title).toBe("");
-    expect(body).toBe("Just a paragraph.");
-  });
-
-  it("does not mistake an H2 for the title", () => {
-    expect(splitTitle("## Subheading\n\nText.").title).toBe("");
+    expect(body).toBe("Just prose.");
   });
 });
 
-describe("buildBlogPost", () => {
-  const article = "# Game of Life\n\nA **cellular automaton**.\n\nSecond paragraph.";
-
-  it("derives the title and slug from the H1", () => {
-    const post = buildBlogPost(article);
-    expect(post.title).toBe("Game of Life");
-    expect(post.slug).toBe("game-of-life");
+describe("escapeForMdx", () => {
+  it("neutralises braces that MDX would read as an expression", () => {
+    // A single unescaped `{` fails the Gatsby build for the whole site.
+    const escaped = escapeForMdx("<p>const x = { a: 1 };</p>");
+    expect(escaped).not.toMatch(/[{}]/);
+    expect(escaped).toContain("&#123;");
+    expect(escaped).toContain("&#125;");
   });
 
-  it("renders the body as HTML without repeating the title", () => {
-    const post = buildBlogPost(article);
-    expect(post.body_html).toContain("<strong>cellular automaton</strong>");
-    expect(post.body_html).toContain("Second paragraph.");
-    expect(post.body_html).not.toContain("Game of Life");
+  it("leaves real HTML tags intact", () => {
+    const escaped = escapeForMdx('<a href="/x">link</a>');
+    expect(escaped).toBe('<a href="/x">link</a>');
+  });
+});
+
+describe("buildPost", () => {
+  const article = "# Lenia\n\nA continuous cellular automaton.";
+
+  it("writes frontmatter gray-matter can read back", () => {
+    const post = buildPost(article, { description: "About Lenia", tags: ["lenia"] });
+    const parsed = matter(post.mdx);
+    expect(parsed.data.title).toBe("Lenia");
+    expect(parsed.data.description).toBe("About Lenia");
+    expect(parsed.data.tags).toEqual(["lenia"]);
   });
 
-  it("always produces a draft with no publish date", () => {
-    const post = buildBlogPost(article);
-    expect(post.status).toBe("unpublished");
-    expect(post.published_at).toBeNull();
+  it("always produces a draft, never a live post", () => {
+    const post = buildPost(article);
+    const parsed = matter(post.mdx);
+    expect(parsed.data.status).toBe("unpublished");
+    expect(parsed.data.published_at).toBeNull();
   });
 
-  it("defaults description and tags to the importer's empty values", () => {
-    const post = buildBlogPost(article);
-    expect(post.description).toBeNull();
-    expect(post.tags).toEqual([]);
+  it("drops the H1 so the site does not render the title twice", () => {
+    const post = buildPost(article);
+    expect(post.mdx).not.toContain("<h1>");
+    expect(matter(post.mdx).content).toContain("continuous cellular automaton");
   });
 
-  it("carries the description and tags through", () => {
-    const post = buildBlogPost(article, {
-      description: "  A short summary.  ",
-      tags: ["cellular-automata"],
-    });
-    expect(post.description).toBe("A short summary.");
-    expect(post.tags).toEqual(["cellular-automata"]);
+  it("keeps the H1 when the caller supplies a different title", () => {
+    const post = buildPost(article, { title: "Another Title" });
+    expect(post.title).toBe("Another Title");
+    expect(post.mdx).toContain("<h1>Lenia</h1>");
   });
 
-  it("keeps the H1 in the body when the title is overridden", () => {
-    const post = buildBlogPost(article, { title: "Conway's Automaton" });
-    expect(post.title).toBe("Conway's Automaton");
-    expect(post.slug).toBe("conways-automaton");
-    expect(post.body_html).toContain("Game of Life");
+  it("carries the cover image path into the frontmatter", () => {
+    const post = buildPost(article, { coverImage: "/images/posts/lenia.png" });
+    expect(matter(post.mdx).data.cover_image).toBe("/images/posts/lenia.png");
+  });
+
+  it("leaves cover_image empty when there is no image", () => {
+    expect(matter(buildPost(article).mdx).data.cover_image).toBe("");
+  });
+
+  it("refuses a title that cannot become a slug", () => {
+    expect(() => buildPost("# !!!\n\nBody.")).toThrow(/empty slug/);
   });
 
   it("refuses an article with no derivable title", () => {
-    expect(() => buildBlogPost("Just prose, no heading.")).toThrow(/title/i);
+    expect(() => buildPost("No heading here.")).toThrow(/Cannot derive a post title/);
+  });
+});
+
+describe("redactSecrets", () => {
+  it("strips credentials embedded in a remote URL", () => {
+    // Child-process output reaches both agent.log and the model's context, so a
+    // token echoed by git must not survive either trip.
+    const redacted = redactSecrets(
+      "fatal: could not read from https://x-access-token:ghp_abcdefghijklmnopqrstuvwxyz123456@github.com/o/r.git",
+    );
+    expect(redacted).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz123456");
+    expect(redacted).not.toContain("x-access-token");
   });
 
-  it("refuses a title that cannot produce a valid slug", () => {
-    expect(() => buildBlogPost("# ???")).toThrow(/slug/i);
+  it("strips a bare token anywhere in the text", () => {
+    expect(redactSecrets("token github_pat_11ABCDEFG0123456789abcdef here")).not.toContain(
+      "github_pat_11ABCDEFG0123456789abcdef",
+    );
+  });
+
+  it("leaves ordinary output untouched", () => {
+    expect(redactSecrets("Everything up-to-date")).toBe("Everything up-to-date");
+  });
+});
+
+describe("blog repo paths", () => {
+  it("names the branch after the slug", () => {
+    expect(articleBranch("lenia")).toBe("articles/lenia");
+  });
+
+  it("points the frontmatter at the served image path, not the repo path", () => {
+    // static/images/posts/x.png is served from /images/posts/x.png.
+    expect(coverImagePath("lenia")).toBe("/images/posts/lenia.png");
+    expect(IMAGES_DIR).toBe(path.join("static", "images", "posts"));
+    expect(POSTS_DIR).toBe(path.join("content", "posts"));
+  });
+});
+
+describe("image generation", () => {
+  afterEach(() => {
+    __resetImageGenerator();
+    mockConfig.geminiApiKey = "";
+  });
+
+  it("forbids text in the generated image", () => {
+    // Models render lettering eagerly and get it wrong; a misspelled cover is
+    // worse than no cover.
+    expect(buildImagePrompt("Lenia")).toMatch(/no text/i);
+  });
+
+  it("includes the article subject and the requested style", () => {
+    const prompt = buildImagePrompt("Lenia", "Continuous cellular automata");
+    expect(prompt).toContain("Lenia");
+    expect(prompt).toContain("Continuous cellular automata");
+    expect(prompt).toMatch(/abstract/i);
+    expect(prompt).toMatch(/geometric/i);
+  });
+
+  it("derives the file extension from the returned MIME type", () => {
+    expect(extensionFor("image/png")).toBe("png");
+    expect(extensionFor("image/jpeg")).toBe("jpg");
+    expect(extensionFor("image/webp")).toBe("webp");
+  });
+
+  it("returns null without an API key, rather than throwing", async () => {
+    __setImageGenerator(async () => {
+      throw new Error("must not call the model without a key");
+    });
+    expect(await generateCoverImage("Lenia")).toBeNull();
+  });
+
+  it("returns null when generation fails, so the article still publishes", async () => {
+    mockConfig.geminiApiKey = "test-key";
+    __setImageGenerator(async () => {
+      throw new Error("model unavailable");
+    });
+    expect(await generateCoverImage("Lenia")).toBeNull();
   });
 });
 
 describe("publishToBlog", () => {
-  let siteDir: string;
-
-  /** Stands up a fake thiagocolen.github.io checkout containing the importer. */
-  const createSiteCheckout = () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "brain-site-"));
-    const script = path.join(dir, BLOG_POST_SCRIPT);
-    fs.mkdirSync(path.dirname(script), { recursive: true });
-    fs.writeFileSync(script, "// stand-in for the real importer\n");
-    return dir;
-  };
-
-  beforeEach(() => {
-    siteDir = createSiteCheckout();
-    mockConfig.blogSitePath = siteDir;
-  });
+  const article = "# Lenia\n\nA continuous cellular automaton.";
 
   afterEach(() => {
-    __resetPostScriptRunner();
-    fs.rmSync(siteDir, { recursive: true, force: true });
-    mockConfig.blogSitePath = "/nonexistent-site-checkout-for-tests";
+    __resetCommandRunner();
+    __resetImageGenerator();
+    mockConfig.geminiApiKey = "";
   });
 
-  it("runs the site's importer against the post JSON it wrote", () => {
-    let seen: { siteDir: string; payload: any } | undefined;
-    __setPostScriptRunner((dir, jsonPath) => {
-      seen = { siteDir: dir, payload: JSON.parse(fs.readFileSync(jsonPath, "utf-8")) };
-      return "✓ Added";
+  /**
+   * Stands in for git and gh.
+   *
+   * The clone is deleted before publishToBlog returns, so anything a test wants
+   * to assert about the committed files has to be captured while it still
+   * exists — `git add` is the moment everything is on disk.
+   */
+  const recordingRunner = () => {
+    const calls: { command: string; args: string[]; cwd?: string }[] = [];
+    const staged: Record<string, Buffer> = {};
+    let repoDir: string | undefined;
+
+    const snapshot = (dir: string, prefix = "") => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        const rel = prefix ? path.join(prefix, entry.name) : entry.name;
+        if (entry.isDirectory()) snapshot(full, rel);
+        else staged[rel] = fs.readFileSync(full);
+      }
+    };
+
+    __setCommandRunner((command, args, cwd) => {
+      calls.push({ command, args, cwd });
+      if (command === "git" && args[0] === "clone") {
+        // Create the directory the real clone would have produced.
+        repoDir = args[args.length - 1];
+        fs.mkdirSync(path.join(repoDir, POSTS_DIR), { recursive: true });
+        return "";
+      }
+      if (command === "git" && args[0] === "add") snapshot(repoDir!);
+      if (command === "gh") return "https://github.com/thiagocolen/thiagocolen.github.io/pull/99\n";
+      return "";
     });
 
-    const result = publishToBlog("# Game of Life\n\nCells.", {
-      description: "About automata.",
-      tags: ["complexity"],
-    });
+    return {
+      calls,
+      staged,
+      stagedText: (rel: string) => staged[rel]?.toString("utf-8"),
+      find: (command: string, sub?: string) =>
+        calls.find((c) => c.command === command && (!sub || c.args.includes(sub))),
+    };
+  };
 
-    expect(seen!.siteDir).toBe(siteDir);
-    expect(seen!.payload).toMatchObject({
-      title: "Game of Life",
-      slug: "game-of-life",
-      status: "unpublished",
-      published_at: null,
-      description: "About automata.",
-      tags: ["complexity"],
-    });
-    expect(result).toContain("game-of-life");
+  it("opens a pull request and reports its URL", async () => {
+    const runner = recordingRunner();
+    const result = await publishToBlog(article, { description: "About Lenia", tags: ["lenia"] });
+
+    expect(result).toContain("https://github.com/thiagocolen/thiagocolen.github.io/pull/99");
+    expect(runner.find("gh", "pr")).toBeTruthy();
   });
 
-  it("tells Pinky the post is a draft, never that it is live", () => {
-    __setPostScriptRunner(() => "✓ Added");
-    const result = publishToBlog("# Game of Life\n\nCells.");
-    expect(result).toMatch(/draft/i);
-    expect(result).toContain("unpublished");
+  it("branches from the configured base, not the repo default", async () => {
+    // master still carries the retired SQLite pipeline and has no content/posts.
+    const runner = recordingRunner();
+    await publishToBlog(article);
+
+    expect(runner.find("git", "clone")!.args).toContain("release/v1.2.0");
+    expect(runner.find("git", "checkout")!.args).toContain("articles/lenia");
+    expect(runner.find("gh")!.args).toContain("release/v1.2.0");
   });
 
-  it("removes the temporary JSON once the importer has run", () => {
-    let jsonPath = "";
-    __setPostScriptRunner((_dir, file) => {
-      jsonPath = file;
-      return "✓ Added";
-    });
-    publishToBlog("# Game of Life\n\nCells.");
-    expect(fs.existsSync(jsonPath)).toBe(false);
+  it("commits the post as a draft at the path the site sources from", async () => {
+    const runner = recordingRunner();
+    await publishToBlog(article, { description: "About Lenia" });
+
+    const written = runner.stagedText(path.join(POSTS_DIR, "lenia.mdx"))!;
+    expect(matter(written).data.status).toBe("unpublished");
+    expect(matter(written).data.title).toBe("Lenia");
   });
 
-  it("cleans up even when the importer fails", () => {
-    let jsonPath = "";
-    __setPostScriptRunner((_dir, file) => {
-      jsonPath = file;
-      throw Object.assign(new Error("Command failed"), { stderr: "slug already published" });
-    });
-    const result = publishToBlog("# Game of Life\n\nCells.");
-    expect(result).toMatch(/^Failed to publish/);
-    expect(result).toContain("slug already published");
-    expect(fs.existsSync(jsonPath)).toBe(false);
+  it("tells Pinky the article is neither live nor merged", async () => {
+    recordingRunner();
+    const result = await publishToBlog(article);
+    expect(result).toMatch(/not live/i);
+    expect(result).toMatch(/not merged/i);
   });
 
-  it("explains how to fix a missing site checkout instead of throwing", () => {
-    mockConfig.blogSitePath = path.join(os.tmpdir(), "definitely-not-a-checkout");
-    __setPostScriptRunner(() => {
-      throw new Error("the importer must not run without a checkout");
+  it("commits a generated cover image and references it in the frontmatter", async () => {
+    mockConfig.geminiApiKey = "test-key";
+    __setImageGenerator(async () => ({
+      bytes: Buffer.from("fake-png-bytes"),
+      mimeType: "image/png",
+      extension: "png",
+    }));
+    const runner = recordingRunner();
+    await publishToBlog(article);
+
+    expect(runner.staged[path.join(IMAGES_DIR, "lenia.png")]?.toString()).toBe("fake-png-bytes");
+    const written = runner.stagedText(path.join(POSTS_DIR, "lenia.mdx"))!;
+    expect(matter(written).data.cover_image).toBe("/images/posts/lenia.png");
+  });
+
+  it("describes the cover image with the format the model actually returned", async () => {
+    // The model picks the format and it is not always PNG. A hardcoded
+    // extension in the PR body described a file that was not in the PR.
+    mockConfig.geminiApiKey = "test-key";
+    __setImageGenerator(async () => ({
+      bytes: Buffer.from("fake-jpeg-bytes"),
+      mimeType: "image/jpeg",
+      extension: "jpg",
+    }));
+    const runner = recordingRunner();
+    await publishToBlog(article);
+
+    expect(runner.staged[path.join(IMAGES_DIR, "lenia.jpg")]).toBeTruthy();
+    const body = runner.find("gh")!.args[runner.find("gh")!.args.indexOf("--body") + 1];
+    expect(body).toContain("lenia.jpg");
+    expect(body).not.toContain("lenia.png");
+  });
+
+  it("still publishes when image generation fails", async () => {
+    mockConfig.geminiApiKey = "test-key";
+    __setImageGenerator(async () => {
+      throw new Error("model unavailable");
     });
-    const result = publishToBlog("# Game of Life\n\nCells.");
-    expect(result).toContain("BLOG_SITE_PATH");
+    const runner = recordingRunner();
+    const result = await publishToBlog(article);
+
+    expect(result).toContain("/pull/99");
+    expect(result).toMatch(/no cover image/i);
+    expect(Object.keys(runner.staged).some((f) => f.includes("images"))).toBe(false);
+  });
+
+  it("refuses to overwrite a post the blog already has", async () => {
+    __setCommandRunner((command, args) => {
+      if (command === "git" && args[0] === "clone") {
+        const repo = args[args.length - 1];
+        fs.mkdirSync(path.join(repo, POSTS_DIR), { recursive: true });
+        fs.writeFileSync(path.join(repo, POSTS_DIR, "lenia.mdx"), "existing post");
+        return "";
+      }
+      if (command === "gh") throw new Error("must not open a PR for a duplicate slug");
+      return "";
+    });
+
+    const result = await publishToBlog(article);
+    expect(result).toMatch(/already has a post/i);
+  });
+
+  it("reports a push failure without leaking the token git echoed", async () => {
+    __setCommandRunner((command, args) => {
+      if (command === "git" && args[0] === "clone") {
+        fs.mkdirSync(path.join(args[args.length - 1], POSTS_DIR), { recursive: true });
+        return "";
+      }
+      if (command === "git" && args.includes("push")) {
+        throw Object.assign(new Error("Command failed"), {
+          stderr: "remote: denied https://x-access-token:ghp_abcdefghijklmnopqrstuvwxyz123456@github.com/o/r.git",
+        });
+      }
+      return "";
+    });
+
+    const result = await publishToBlog(article);
+    expect(result).toMatch(/could not push/i);
+    expect(result).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz123456");
+  });
+
+  it("removes the clone even when publishing fails", async () => {
+    let repoDir: string | undefined;
+    __setCommandRunner((command, args) => {
+      if (command === "git" && args[0] === "clone") {
+        repoDir = args[args.length - 1];
+        fs.mkdirSync(path.join(repoDir, POSTS_DIR), { recursive: true });
+        return "";
+      }
+      throw Object.assign(new Error("Command failed"), { stderr: "boom" });
+    });
+
+    await publishToBlog(article);
+    expect(fs.existsSync(path.dirname(repoDir!))).toBe(false);
   });
 });
 
 describe("resolveExportPath", () => {
-  it("places the article inside the folder Pinky named", () => {
-    const target = resolveExportPath(path.join(os.tmpdir(), "pinky-out"), "game-of-life.md");
-    expect(path.dirname(target)).toBe(path.join(os.tmpdir(), "pinky-out"));
-    expect(path.basename(target)).toBe("game-of-life.md");
+  it("keeps the filename flat inside the folder Pinky named", () => {
+    const resolved = resolveExportPath(path.join(os.tmpdir(), "out"), "my-article.md");
+    expect(path.dirname(resolved)).toBe(path.join(os.tmpdir(), "out"));
+    expect(path.basename(resolved)).toBe("my-article.md");
   });
 
-  it("resolves a relative folder against the working directory", () => {
-    expect(resolveExportPath("out/articles", "a.md")).toBe(
-      path.join(process.cwd(), "out", "articles", "a.md"),
-    );
-  });
-
-  it("keeps a traversing filename inside the destination folder", () => {
-    const dest = path.join(os.tmpdir(), "pinky-out");
-    const target = resolveExportPath(dest, "../../etc/passwd");
-    expect(path.dirname(target)).toBe(dest);
-    expect(path.basename(target)).toBe("passwd.md");
-  });
-
-  it("appends .md to an extensionless name", () => {
-    expect(path.basename(resolveExportPath("out", "Game of Life"))).toBe("Game-of-Life.md");
+  it("expands a leading ~ to the home directory", () => {
+    expect(resolveExportPath("~/docs", "a.md")).toBe(path.join(os.homedir(), "docs", "a.md"));
   });
 });
 
@@ -250,7 +437,7 @@ describe("Delivery tools", () => {
 
   afterEach(() => {
     cwdSpy.mockRestore();
-    __resetPostScriptRunner();
+    __resetCommandRunner();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -297,8 +484,8 @@ describe("Delivery tools", () => {
   });
 
   it("refuses to publish an article that was never saved", async () => {
-    __setPostScriptRunner(() => {
-      throw new Error("must not reach the importer");
+    __setCommandRunner(() => {
+      throw new Error("must not touch the blog repo");
     });
     const publishArticle = await getTool("publish_article");
     const result: any = await publishArticle.invoke({ filename: "never-written.md" });
@@ -316,5 +503,14 @@ describe("Delivery instructions in the system prompt", () => {
   it("requires Pinky to choose before anything leaves the conversation", () => {
     expect(BRAIN_SYSTEM_PROMPT).toMatch(/never on your own initiative/i);
     expect(BRAIN_SYSTEM_PROMPT).toMatch(/Never claim an article is live/i);
+  });
+
+  it("requires confirmation before pushing to a public repository", () => {
+    expect(BRAIN_SYSTEM_PROMPT).toMatch(/confirmation before you act/i);
+  });
+
+  it("makes The Brain report the pull request, not a publication", () => {
+    expect(BRAIN_SYSTEM_PROMPT).toMatch(/pull request URL/i);
+    expect(BRAIN_SYSTEM_PROMPT).toMatch(/not merged/i);
   });
 });

--- a/src/utils/blog-repo.ts
+++ b/src/utils/blog-repo.ts
@@ -1,0 +1,274 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { config } from "../config.js";
+import { logger } from "./logger.js";
+
+/**
+ * Delivery of an article to the blog, which is a *separate repository*
+ * (thiagocolen.github.io) rather than anything inside this project.
+ *
+ * The article is not written into a checkout on this machine. It is clone →
+ * branch → commit → push → pull request, so the change is reviewable, the
+ * audit trail is the PR, and nothing depends on the operator happening to have
+ * the blog checked out. Approval becomes a real GitHub review rather than an
+ * honour-system prompt.
+ */
+
+/** Where posts live in the blog repo. Filename minus extension is the slug. */
+export const POSTS_DIR = path.join("content", "posts");
+
+/**
+ * Where cover images are committed.
+ *
+ * Gatsby copies a root `static/` directory into the build output verbatim, with
+ * no plugin or config, so `static/images/posts/x.png` is served at
+ * `/images/posts/x.png` — which is what the frontmatter references. The blog has
+ * no image pipeline (`gatsby-plugin-image` and `sharp` are installed but never
+ * registered), and it needs none: cover images are interpolated straight into a
+ * CSS `url()`.
+ */
+export const IMAGES_DIR = path.join("static", "images", "posts");
+
+/** Public path of a post's cover image, as written into the frontmatter. */
+export function coverImagePath(slug: string, extension = "png"): string {
+  return `/images/posts/${slug}.${extension}`;
+}
+
+/** Branch created for a new article. `articles/*` is unused by the blog repo. */
+export function articleBranch(slug: string): string {
+  return `articles/${slug}`;
+}
+
+/**
+ * Git can block forever waiting on a credential prompt, and a hung child here
+ * hangs the whole agent turn. Every invocation is bounded and non-interactive.
+ */
+const CHILD_TIMEOUT_MS = 120_000;
+const CHILD_MAX_BUFFER = 10 * 1024 * 1024;
+
+/**
+ * Strips anything that looks like a credential out of child-process output.
+ *
+ * This matters more than it looks: child output is written to `agent.log` *and*
+ * returned into the model's context. Git echoes remote URLs freely, so a single
+ * `https://user:token@github.com/...` in an error message would leak a live
+ * token to both. Credentials are never interpolated into a URL here, but
+ * redaction is the backstop for anything the environment supplies.
+ */
+export function redactSecrets(text: unknown): string {
+  return String(text ?? "")
+    .replace(/(https?:\/\/)[^\s/@]+@/gi, "$1<redacted>@")
+    .replace(/gh[pousr]_[A-Za-z0-9]{16,}/g, "<redacted-token>")
+    .replace(/github_pat_[A-Za-z0-9_]{16,}/g, "<redacted-token>");
+}
+
+/** Test seam: every external command, isolated so tests never touch the network. */
+export type CommandRunner = (command: string, args: string[], cwd?: string) => string;
+
+const defaultRunner: CommandRunner = (command, args, cwd) =>
+  execFileSync(command, args, {
+    cwd,
+    encoding: "utf-8",
+    timeout: CHILD_TIMEOUT_MS,
+    maxBuffer: CHILD_MAX_BUFFER,
+    stdio: ["ignore", "pipe", "pipe"],
+    // Never let git stop for an interactive prompt: fail fast instead.
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+  });
+
+let runCommand: CommandRunner = defaultRunner;
+
+export function __setCommandRunner(runner: CommandRunner): void {
+  runCommand = runner;
+}
+
+export function __resetCommandRunner(): void {
+  runCommand = defaultRunner;
+}
+
+/** Harvests everything a failed child process reported, with secrets removed. */
+function describeFailure(e: any): string {
+  const detail = [e?.stderr, e?.stdout, e?.message]
+    .filter(Boolean)
+    .map((part) => redactSecrets(part))
+    .join("\n")
+    .trim();
+  return detail || "no output";
+}
+
+export interface CoverImage {
+  bytes: Buffer;
+  /** File extension without the dot, e.g. "png". */
+  extension: string;
+}
+
+export interface PublishRequest {
+  slug: string;
+  title: string;
+  /** Full MDX file contents: frontmatter plus body. */
+  mdx: string;
+  image?: CoverImage | null;
+}
+
+export interface PublishResult {
+  prUrl: string;
+  branch: string;
+  imageIncluded: boolean;
+}
+
+/**
+ * Clones the blog, commits the article on its own branch, and opens a PR.
+ *
+ * Throws on failure with a message safe to show — callers turn that into a
+ * sentence for Pinky. The clone is always removed, including on failure.
+ */
+export function publishArticleAsPullRequest(request: PublishRequest): PublishResult {
+  const { slug, title, mdx, image } = request;
+  const branch = articleBranch(slug);
+  const baseBranch = config.blogBaseBranch;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brain-blog-"));
+
+  try {
+    const repo = path.join(tmpDir, "site");
+    try {
+      runCommand("git", [
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        baseBranch,
+        config.blogRepoUrl,
+        repo,
+      ]);
+    } catch (e: any) {
+      throw new Error(
+        `Could not clone the blog (${config.blogRepoUrl}, branch ${baseBranch}): ${describeFailure(e)}`,
+      );
+    }
+
+    // Mirror the blog's own new-post.js, which refuses to overwrite a post.
+    const postPath = path.join(repo, POSTS_DIR, `${slug}.mdx`);
+    if (fs.existsSync(postPath)) {
+      throw new Error(
+        `The blog already has a post at ${POSTS_DIR}/${slug}.mdx on ${baseBranch}. ` +
+          `Rename the article or update the existing post by hand.`,
+      );
+    }
+
+    runCommand("git", ["checkout", "-b", branch], repo);
+
+    fs.mkdirSync(path.dirname(postPath), { recursive: true });
+    fs.writeFileSync(postPath, mdx, "utf-8");
+
+    let imageIncluded = false;
+    if (image) {
+      const imagePath = path.join(repo, IMAGES_DIR, `${slug}.${image.extension}`);
+      fs.mkdirSync(path.dirname(imagePath), { recursive: true });
+      fs.writeFileSync(imagePath, image.bytes);
+      imageIncluded = true;
+    }
+
+    runCommand("git", ["add", "--all"], repo);
+    runCommand(
+      "git",
+      [
+        // Set identity per-invocation: the agent must not depend on, or alter,
+        // whatever global git identity this machine happens to have.
+        "-c",
+        "user.name=The Brain",
+        "-c",
+        "user.email=the-brain@users.noreply.github.com",
+        "commit",
+        "-m",
+        `content: add "${title}" as a draft${imageIncluded ? " with cover image" : ""}`,
+      ],
+      repo,
+    );
+
+    try {
+      runCommand(
+        "git",
+        [
+          // Borrow the gh CLI's credentials for this push only, rather than
+          // relying on (or rewriting) the machine's global git credential setup.
+          "-c",
+          "credential.helper=",
+          "-c",
+          "credential.https://github.com.helper=!gh auth git-credential",
+          "push",
+          "-u",
+          "origin",
+          branch,
+        ],
+        repo,
+      );
+    } catch (e: any) {
+      throw new Error(
+        `Could not push branch ${branch} to the blog: ${describeFailure(e)}. ` +
+          `Check that the gh CLI is signed in with write access.`,
+      );
+    }
+
+    let prUrl: string;
+    try {
+      prUrl = runCommand(
+        "gh",
+        [
+          "pr",
+          "create",
+          "--base",
+          baseBranch,
+          "--head",
+          branch,
+          "--title",
+          `content: add "${title}"`,
+          "--body",
+          prBody(slug, title, image?.extension ?? null, baseBranch),
+        ],
+        repo,
+      )
+        .trim()
+        .split(/\s+/)
+        .filter((line) => line.startsWith("http"))
+        .pop() as string;
+    } catch (e: any) {
+      throw new Error(
+        `Pushed branch ${branch}, but opening the pull request failed: ${describeFailure(e)}. ` +
+          `The branch is on GitHub — a PR can still be opened by hand.`,
+      );
+    }
+
+    logger.info(`[BlogRepo] Opened ${prUrl} for "${title}"`);
+    return { prUrl, branch, imageIncluded };
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * PR description. States plainly that merging does not publish anything.
+ *
+ * `extension` rather than a boolean: the model picks the format, and it is not
+ * always PNG — a hardcoded extension here would describe a file that does not
+ * exist in the very PR it is describing.
+ */
+function prBody(slug: string, title: string, extension: string | null, baseBranch: string): string {
+  return [
+    `Draft article written by The Brain.`,
+    ``,
+    `- **Post:** \`${POSTS_DIR}/${slug}.mdx\``,
+    extension
+      ? `- **Cover image:** \`${IMAGES_DIR}/${slug}.${extension}\` → \`${coverImagePath(slug, extension)}\``
+      : `- **Cover image:** none`,
+    `- **Status:** \`unpublished\` — merging this PR does **not** put the article live.`,
+    ``,
+    `\`gatsby build\` only includes posts with \`status: published\`, so this stays`,
+    `invisible on the site (and in this PR's preview deploy) until it is promoted with`,
+    `\`npm run publish-post -- ${slug}\` on \`${baseBranch}\`.`,
+    ``,
+    `To read it before merging: check out this branch and run \`npm run develop\`,`,
+    `which does include drafts.`,
+  ].join("\n");
+}

--- a/src/utils/image-gen.ts
+++ b/src/utils/image-gen.ts
@@ -1,0 +1,128 @@
+import { GoogleGenAI } from "@google/genai";
+import { config } from "../config.js";
+import { logger } from "./logger.js";
+
+/**
+ * Cover-image generation for published articles.
+ *
+ * Scope note: this agent is deliberately Anthropic-only for *text* (see
+ * src/utils/model.ts). Google appears here for image generation alone, because
+ * Anthropic models do not generate images. Nothing in the reasoning or writing
+ * path goes through this module.
+ *
+ * Every failure is soft. A missing key, a refusal, a network error — all return
+ * null, and the article publishes without a cover. An image is a nice-to-have;
+ * losing the article because of it would not be.
+ */
+
+/** Style keywords for every cover: abstract artwork, never a photograph. */
+const STYLE_KEYWORDS = "abstract geometric line drawing, flat vector art, bold shapes, limited palette";
+
+/**
+ * Aspect ratio matching where covers are actually displayed — a short banner on
+ * the post page and a wide card thumbnail in the listing, both cropped via CSS
+ * `background-size: cover`.
+ */
+const ASPECT_RATIO = "16:9";
+
+export interface GeneratedImage {
+  bytes: Buffer;
+  mimeType: string;
+  /** File extension without the dot, derived from the returned MIME type. */
+  extension: string;
+}
+
+/**
+ * Builds the prompt.
+ *
+ * The "no text" instruction is not decoration: image models render lettering
+ * eagerly and get it subtly wrong, and a cover with a misspelled word on it
+ * looks far worse than a cover with no word at all.
+ */
+export function buildImagePrompt(title: string, description?: string): string {
+  const subject = [title, description].filter(Boolean).join(". ");
+  return (
+    `Cover illustration for a technical article about: ${subject}. ` +
+    `Style: ${STYLE_KEYWORDS}. ` +
+    `Absolutely no text, no words, no letters, no numbers, no captions, no watermarks. ` +
+    `Composition should read clearly when cropped to a wide banner.`
+  );
+}
+
+/** Maps a returned MIME type to a file extension. */
+export function extensionFor(mimeType: string): string {
+  if (/jpe?g/i.test(mimeType)) return "jpg";
+  if (/webp/i.test(mimeType)) return "webp";
+  return "png";
+}
+
+/** Test seam: the model call, so tests never reach the network. */
+export type ImageGenerator = (prompt: string) => Promise<GeneratedImage | null>;
+
+const defaultGenerator: ImageGenerator = async (prompt) => {
+  const ai = new GoogleGenAI({ apiKey: config.geminiApiKey });
+
+  const response = await ai.models.generateContent({
+    model: config.geminiImageModel,
+    contents: prompt,
+    config: {
+      responseModalities: ["IMAGE"],
+      imageConfig: { aspectRatio: ASPECT_RATIO },
+    },
+  });
+
+  const parts = response?.candidates?.[0]?.content?.parts ?? [];
+  for (const part of parts) {
+    const inline = part.inlineData;
+    if (inline?.data) {
+      const mimeType = inline.mimeType || "image/png";
+      return {
+        bytes: Buffer.from(inline.data, "base64"),
+        mimeType,
+        extension: extensionFor(mimeType),
+      };
+    }
+  }
+  return null;
+};
+
+let generate: ImageGenerator = defaultGenerator;
+
+export function __setImageGenerator(generator: ImageGenerator): void {
+  generate = generator;
+}
+
+export function __resetImageGenerator(): void {
+  generate = defaultGenerator;
+}
+
+/**
+ * Generates a cover image, or returns null if one cannot be had.
+ *
+ * Never throws: the caller is mid-publish and an article without a picture is a
+ * far better outcome than a failed publish.
+ */
+export async function generateCoverImage(
+  title: string,
+  description?: string,
+): Promise<GeneratedImage | null> {
+  if (!config.geminiApiKey) {
+    logger.info("[ImageGen] No GEMINI_API_KEY set — publishing without a cover image.");
+    return null;
+  }
+
+  try {
+    const image = await generate(buildImagePrompt(title, description));
+    if (!image) {
+      logger.warn(`[ImageGen] ${config.geminiImageModel} returned no image for "${title}".`);
+      return null;
+    }
+    logger.info(
+      `[ImageGen] Generated a ${image.mimeType} cover for "${title}" (${image.bytes.length} bytes)`,
+    );
+    return image;
+  } catch (e: any) {
+    logger.error(`[ImageGen] Cover generation failed for "${title}": ${e?.message ?? e}`);
+    return null;
+  }
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from "crypto";
+
+/**
+ * Thread identity for the MCP entrypoint.
+ *
+ * Every entrypoint keys LangGraph checkpoints by `thread_id`, so the thread is
+ * what makes The Brain's journey (greet → topic → subtopic → action) advance
+ * instead of restarting. MCP has no session handshake of its own — unlike ACP,
+ * which gets a `sessionId` from `session/new` — so the server process itself is
+ * the session boundary: one running MCP server, one journey.
+ */
+
+/** One thread per MCP server process, so a client session is one journey. */
+export const MCP_SESSION_THREAD_ID = `mcp-session-${randomUUID()}`;
+
+/**
+ * Resolves the thread a tool call runs on.
+ *
+ * An explicit id wins, so a caller can deliberately branch into a separate
+ * journey. Anything blank falls back to this process's thread — never to a
+ * fresh one, which would strand the conversation on step one forever.
+ */
+export function resolveThreadId(explicit?: string): string {
+  const trimmed = explicit?.trim();
+  return trimmed ? trimmed : MCP_SESSION_THREAD_ID;
+}


### PR DESCRIPTION
Closes #29.

Three things on the way to v0.3.0: finished articles had nowhere to go, they had no cover images, and the MCP conversation restarted on every call.

## Publishing is a pull request

Once The Brain finishes an article, **Step 4c** of the journey asks Pinky where it should go, backed by two tools:

| Tool | What it does |
| --- | --- |
| `publish_article` | Generates a cover image, then clones the blog, commits the post on a branch `articles/<slug>`, pushes, and opens a **pull request**. Returns the PR URL. |
| `export_article` | Copies the article into any folder Pinky names. |

The blog ([thiagocolen.github.io](https://github.com/thiagocolen/thiagocolen.github.io)) is a **separate repository**, and this treats it as a remote collaboration target rather than a local dependency — nothing requires the operator to have it checked out, and the audit trail is the PR itself. Approval becomes a real GitHub review instead of an honour-system prompt in the conversation.

**Nothing goes live.** Posts are committed with `status: unpublished` and `published_at: null`. `gatsby build` only includes published posts, so the article stays invisible on the site **even after the blog-side PR merges** — promoting it stays a human action (`npm run publish-post -- <slug>`). The prompt forbids claiming an article is live, published, or merged, and requires Pinky's confirmation before anything is pushed to a public repo.

Two details that keep output consistent with the blog's own tooling rather than merely similar to it: frontmatter is serialised with `gray-matter`, the same library `develop-tools/new-post.js` uses; and `slugify` matches that script exactly, apostrophes included — `"Conway's Game"` becomes `conway-s-game`, not `conways-game`.

## Cover images

Generated with `gemini-3.1-flash-lite-image` from the title plus fixed style keywords (abstract, geometric, flat vector), committed to `static/images/posts/<slug>.<ext>` and referenced from the frontmatter. Gatsby copies a root `static/` directory into the build verbatim, so this needs no plugin — which matters, because the blog has no image pipeline at all and `cover_image` is interpolated straight into a CSS `url()`.

The prompt forbids text in the image: models render lettering eagerly and get it subtly wrong, and a cover with a misspelled word looks worse than one with none.

Generation is soft-failing throughout — no key, a refusal, or a network error returns null and the article publishes without a picture. This is also the **only** non-Anthropic model in the project; every text path remains Anthropic-only.

## MCP conversations no longer restart every call

`run_agent` generated a fresh random `threadId` whenever the caller omitted one, so every call landed on a new LangGraph checkpoint — the journey was stranded on the topic menu forever. `src/utils/session.ts` now pins **one thread per server process**; MCP has no session handshake of its own (unlike ACP's `session/new`), so the process is the session boundary. An explicit `threadId` still wins.

The tool description now says the conversation is multi-turn and that `threadId` should be omitted, and the `agentName` enum was trimmed to the routes that actually exist — the deepagents rebuild removed `developer`, `writer`, `instructor`, `specialist`, `publisher`.

## MCP startup no longer needs `PATBA_API_KEY`

It authenticates callers of the REST API, which this entrypoint does not serve. MCP clients spawn servers with a filtered environment, so demanding an unused secret was a hard startup failure for no security benefit. `validateConfig` takes `requirePatbaApiKey`; `src/mcp.ts` opts out. `npm run server` still requires it.

## Hardening

- Git child processes get a `timeout`, a `maxBuffer`, and `GIT_TERMINAL_PROMPT=0` — git blocks forever on a credential prompt, and a hung child hangs the agent turn.
- `redactSecrets` strips credentials from child output before it is logged or returned. That output reaches both `agent.log` and the model's context, so a token echoed inside a remote URL would leak to both. Credentials are never interpolated into a URL here; this is the backstop.
- Pushing borrows the `gh` CLI's credential helper for that one invocation rather than depending on, or rewriting, the machine's global git config.

## Also

- Ships a project-scoped `.mcp.json`. Deliberately **no `env` block** — credentials come from `.env` via `src/config.ts`, which resolves from the compiled file's location.
- Config: adds `BLOG_REPO_URL`, `BLOG_BASE_BRANCH`, `GEMINI_API_KEY`, `GEMINI_IMAGE_MODEL`. No new key is required at startup.
- Documents all of it in the MCP usage and configuration guides.

## Testing

- `npm run test:unit` — **80 passed**
- `npm run build` — clean
- Beyond mocks, the pipeline was run against the **live blog repo** with only `push` and `gh pr create` stubbed: real clone of `release/v1.2.0`, correct frontmatter, both files committed, MDX brace escaping confirmed, and a real generated image. That run caught a bug — the model returned JPEG where the code assumed PNG — now fixed and regression tested.

## Notes for review

- **Base branch on the blog is `release/v1.2.0`, not `master`.** `master` still carries the retired SQLite content pipeline and has no `content/posts/`, so an `.mdx` file merged there would never render. (The blog also has a similarly named `release-v120` without slashes — that is the old branch.)
- **A draft will not appear in the blog's PR preview deploy**, because that runs `gatsby build`, which filters to published posts. Reviewing means reading the MDX diff or running `gatsby develop`. By design, not a bug.
- **Commits to the blog are authored by the `gh` account in use**, currently `penny-processor`, not `thiagocolen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLi3M5mFwEQ9CD7D4PFgUX
